### PR TITLE
Remove API method monkey patching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 *.coverage
 .cache/
 tests/__pycache__/
+*.DS_Store

--- a/arango/api.py
+++ b/arango/api.py
@@ -1,40 +1,11 @@
-from __future__ import absolute_import, unicode_literals
-
-from functools import wraps
+from abc import ABCMeta
 
 
-class APIWrapper(object):
-    """ArangoDB API wrapper base class.
+class APIWrapper:
+    __metaclass__ = ABCMeta
 
-    This class is meant to be used internally only.
-    """
+    def __init__(self, connection):
+        self._conn = connection
 
-    def __getattribute__(self, attr):
-        method = object.__getattribute__(self, attr)
-        conn = object.__getattribute__(self, '_conn')
-
-        if not getattr(method, 'api_method', False):
-            return method
-
-        @wraps(method)
-        def wrapped_method(*args, **kwargs):
-            request, handler = method(*args, **kwargs)
-            return conn.handle_request(request, handler)
-        return wrapped_method
-
-
-def api_method(method):
-    """Decorator used to mark ArangoDB API methods.
-
-    Methods decorated by this should return two things:
-
-    - An instance of :class:`arango.request.Request`
-    - A handler that takes an instance of :class:`arango.response.Response`
-
-    :param method: the method to wrap
-    :type method: callable
-    :returns: the wrapped method
-    :rtype: callable
-    """
-    setattr(method, 'api_method', True)
-    return method
+    def handle_request(self, request, handler):
+        return self._conn.handle_request(request, handler)

--- a/arango/aql.py
+++ b/arango/aql.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from arango.api import APIWrapper, api_method
 from arango.utils import HTTP_OK
 from arango.cursor import Cursor
 from arango.exceptions import (
@@ -16,6 +15,8 @@ from arango.exceptions import (
 )
 from arango.request import Request
 
+from arango.api import APIWrapper
+
 
 class AQL(APIWrapper):
     """Wrapper for invoking ArangoDB Query Language (AQL).
@@ -25,7 +26,7 @@ class AQL(APIWrapper):
     """
 
     def __init__(self, connection):
-        self._conn = connection
+        super(AQL, self).__init__(connection)
         self._cache = AQLQueryCache(self._conn)
 
     def __repr__(self):
@@ -40,7 +41,6 @@ class AQL(APIWrapper):
         """
         return self._cache
 
-    @api_method
     def explain(self, query, all_plans=False, max_plans=None, opt_rules=None):
         """Inspect the query and return its metadata.
 
@@ -75,9 +75,8 @@ class AQL(APIWrapper):
                 raise AQLQueryExplainError(res)
             return res.body['plan' if 'plan' in res.body else 'plans']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def validate(self, query):
         """Validate the query.
 
@@ -101,9 +100,8 @@ class AQL(APIWrapper):
             res.body.pop('error', None)
             return res.body
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def execute(self, query, count=False, batch_size=None, ttl=None,
                 bind_vars=None, full_count=None, max_plans=None,
                 optimizer_rules=None):
@@ -160,9 +158,8 @@ class AQL(APIWrapper):
                 raise AQLQueryExecuteError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def functions(self):
         """List the AQL functions defined in this database.
 
@@ -179,9 +176,8 @@ class AQL(APIWrapper):
             body = res.body or {}
             return {func['name']: func['code'] for func in map(dict, body)}
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def create_function(self, name, code):
         """Create a new AQL function.
 
@@ -205,9 +201,8 @@ class AQL(APIWrapper):
                 raise AQLFunctionCreateError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete_function(self, name, group=None, ignore_missing=False):
         """Delete the AQL function of the given name.
 
@@ -240,7 +235,7 @@ class AQL(APIWrapper):
                     raise AQLFunctionDeleteError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
 
 class AQLQueryCache(APIWrapper):
@@ -250,10 +245,6 @@ class AQLQueryCache(APIWrapper):
     :type connection: arango.connection.Connection
     """
 
-    def __init__(self, connection):
-        self._conn = connection
-
-    @api_method
     def properties(self):
         """Return the properties of the query cache.
 
@@ -272,9 +263,8 @@ class AQLQueryCache(APIWrapper):
                 raise AQLCachePropertiesError(res)
             return {'mode': res.body['mode'], 'limit': res.body['maxResults']}
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def configure(self, mode=None, limit=None):
         """Configure the AQL query cache.
 
@@ -304,9 +294,8 @@ class AQLQueryCache(APIWrapper):
                 raise AQLCacheConfigureError(res)
             return {'mode': res.body['mode'], 'limit': res.body['maxResults']}
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def clear(self):
         """Clear any results in the query cache.
 
@@ -322,4 +311,4 @@ class AQLQueryCache(APIWrapper):
                 raise AQLCacheClearError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)

--- a/arango/client.py
+++ b/arango/client.py
@@ -553,7 +553,7 @@ class ArangoClient(object):
         res = self._conn.post('/_admin/routing/reload')
         if res.status_code not in HTTP_OK:
             raise ServerReloadRoutingError(res)
-        return not res.body['error']
+        return 'error' not in res.body
 
     #######################
     # Database Management #

--- a/arango/collections/base.py
+++ b/arango/collections/base.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from arango.api import APIWrapper, api_method
+from arango.api import APIWrapper
 from arango.cursor import Cursor, ExportCursor
 from arango.exceptions import *
 from arango.request import Request
@@ -31,7 +31,7 @@ class BaseCollection(APIWrapper):
     }
 
     def __init__(self, connection, name):
-        self._conn = connection
+        super(BaseCollection, self).__init__(connection)
         self._name = name
 
     def __iter__(self):
@@ -134,7 +134,6 @@ class BaseCollection(APIWrapper):
         """
         return self._conn.database
 
-    @api_method
     def rename(self, new_name):
         """Rename the collection.
 
@@ -163,9 +162,8 @@ class BaseCollection(APIWrapper):
                 'type': self.TYPES[res.body['type']]
             }
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def statistics(self):
         """Return the collection statistics.
 
@@ -192,9 +190,8 @@ class BaseCollection(APIWrapper):
             )
             return stats
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def revision(self):
         """Return the collection revision.
 
@@ -213,9 +210,8 @@ class BaseCollection(APIWrapper):
                 raise CollectionRevisionError(res)
             return res.body['revision']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def properties(self):
         """Return the collection properties.
 
@@ -251,9 +247,8 @@ class BaseCollection(APIWrapper):
                 'key_offset': key_options.get('offset')
             }
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def configure(self, sync=None, journal_size=None):
         """Configure the collection properties.
 
@@ -302,9 +297,8 @@ class BaseCollection(APIWrapper):
                 'key_offset': key_options.get('offset')
             }
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def load(self):
         """Load the collection into memory.
 
@@ -324,9 +318,8 @@ class BaseCollection(APIWrapper):
                 raise CollectionLoadError(res)
             return self._status(res.body['status'])
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def unload(self):
         """Unload the collection from memory.
 
@@ -346,9 +339,8 @@ class BaseCollection(APIWrapper):
                 raise CollectionUnloadError(res)
             return self._status(res.body['status'])
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def rotate(self):
         """Rotate the collection journal.
 
@@ -368,9 +360,8 @@ class BaseCollection(APIWrapper):
                 raise CollectionRotateJournalError(res)
             return res.body['result']  # pragma: no cover
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def checksum(self, with_rev=False, with_data=False):
         """Return the collection checksum.
 
@@ -396,9 +387,8 @@ class BaseCollection(APIWrapper):
                 raise CollectionChecksumError(res)
             return int(res.body['checksum'])
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def truncate(self):
         """Truncate the collection.
 
@@ -424,9 +414,8 @@ class BaseCollection(APIWrapper):
                 'type': self.TYPES[res.body['type']]
             }
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def count(self):
         """Return the number of documents in the collection.
 
@@ -445,9 +434,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentCountError(res)
             return res.body['count']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def has(self, key, rev=None, match_rev=True):
         """Check if a document exists in the collection by its key.
 
@@ -484,9 +472,8 @@ class BaseCollection(APIWrapper):
                 return True
             raise DocumentInError(res)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def all(self,
             skip=None,
             limit=None):
@@ -519,9 +506,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def export(self,
                limit=None,
                count=False,
@@ -588,9 +574,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return ExportCursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def find(self, filters, offset=None, limit=None):
         """Return all documents that match the given filters.
 
@@ -622,9 +607,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def get_many(self, keys):
         """Return multiple documents by their keys.
 
@@ -646,9 +630,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return res.body['documents']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def random(self):
         """Return a random document from the collection.
 
@@ -668,9 +651,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return res.body['document']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def find_near(self, latitude, longitude, limit=None):
         """Return documents near a given coordinate.
 
@@ -718,9 +700,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def find_in_range(self,
                       field,
                       lower,
@@ -785,10 +766,9 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
     # TODO the WITHIN geo function does not seem to work properly
-    @api_method
     def find_in_radius(self, latitude, longitude, radius, distance_field=None):
         """Return documents within a given radius in a random order.
 
@@ -834,9 +814,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def find_in_box(self,
                     latitude1,
                     longitude1,
@@ -892,9 +871,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def find_by_text(self, key, query, limit=None):
         """Return documents that match the specified fulltext **query**.
 
@@ -933,9 +911,8 @@ class BaseCollection(APIWrapper):
                 raise DocumentGetError(res)
             return Cursor(self._conn, res.body)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def indexes(self):
         """Return the collection indexes.
 
@@ -969,7 +946,7 @@ class BaseCollection(APIWrapper):
                 indexes.append(index)
             return indexes
 
-        return request, handler
+        return self.handle_request(request, handler)
 
     def _add_index(self, data):
         """Helper method for creating a new index."""
@@ -999,9 +976,8 @@ class BaseCollection(APIWrapper):
                 details['new'] = details.pop('isNewlyCreated')
             return details
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def add_hash_index(self,
                        fields,
                        unique=None,
@@ -1037,7 +1013,6 @@ class BaseCollection(APIWrapper):
             data['deduplicate'] = deduplicate
         return self._add_index(data)
 
-    @api_method
     def add_skiplist_index(self,
                            fields,
                            unique=None,
@@ -1075,7 +1050,6 @@ class BaseCollection(APIWrapper):
             data['deduplicate'] = deduplicate
         return self._add_index(data)
 
-    @api_method
     def add_geo_index(self, fields, ordered=None):
         """Create a geo-spatial index in the collection.
 
@@ -1096,7 +1070,6 @@ class BaseCollection(APIWrapper):
             data['geoJson'] = ordered
         return self._add_index(data)
 
-    @api_method
     def add_fulltext_index(self, fields, min_length=None):
         """Create a fulltext index in the collection.
 
@@ -1124,7 +1097,6 @@ class BaseCollection(APIWrapper):
             data['minLength'] = min_length
         return self._add_index(data)
 
-    @api_method
     def add_persistent_index(self, fields, unique=None, sparse=None):
         """Create a persistent index in the collection.
 
@@ -1152,7 +1124,6 @@ class BaseCollection(APIWrapper):
             data['sparse'] = sparse
         return self._add_index(data)
 
-    @api_method
     def delete_index(self, index_id, ignore_missing=False):
         """Delete an index from the collection.
 
@@ -1179,9 +1150,8 @@ class BaseCollection(APIWrapper):
                 raise IndexDeleteError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def user_access(self, username):
         """Return a user's access details for the collection.
 
@@ -1206,9 +1176,8 @@ class BaseCollection(APIWrapper):
                 return None if result == 'none' else result
             raise UserAccessError(res)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def grant_user_access(self, username):
         """Grant user access to the collection.
 
@@ -1233,9 +1202,8 @@ class BaseCollection(APIWrapper):
                 return True
             raise UserGrantAccessError(res)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def revoke_user_access(self, username):
         """Revoke user access to the collection.
 
@@ -1259,4 +1227,4 @@ class BaseCollection(APIWrapper):
                 return True
             raise UserRevokeAccessError(res)
 
-        return request, handler
+        return self.handle_request(request, handler)

--- a/arango/collections/edge.py
+++ b/arango/collections/edge.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from arango.api import api_method
 from arango.collections.base import BaseCollection
 from arango.exceptions import *
 from arango.request import Request
@@ -46,7 +45,6 @@ class EdgeCollection(BaseCollection):
         """
         return self._graph_name
 
-    @api_method
     def get(self, key, rev=None):
         """Fetch a document by key from the edge collection.
 
@@ -78,9 +76,8 @@ class EdgeCollection(BaseCollection):
                 raise DocumentGetError(res)
             return res.body["edge"]
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def insert(self, document, sync=None):
         """Insert a new document into the edge collection.
 
@@ -115,9 +112,8 @@ class EdgeCollection(BaseCollection):
                 raise DocumentInsertError(res)
             return res.body["edge"]
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def update(self, document, keep_none=True, sync=None):
         """Update a document by its key in the edge collection.
 
@@ -167,9 +163,8 @@ class EdgeCollection(BaseCollection):
             edge['_old_rev'] = edge.pop('_oldRev')
             return edge
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def replace(self, document, sync=None):
         """Replace a document by its key in the edge collection.
 
@@ -214,9 +209,8 @@ class EdgeCollection(BaseCollection):
             edge['_old_rev'] = edge.pop('_oldRev')
             return edge
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete(self, document, ignore_missing=False, sync=None):
         """Delete a document from the collection by its key.
 
@@ -266,4 +260,4 @@ class EdgeCollection(BaseCollection):
                 raise DocumentDeleteError(res)
             return res.body['removed']
 
-        return request, handler
+        return self.handle_request(request, handler)

--- a/arango/collections/standard.py
+++ b/arango/collections/standard.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 from json import dumps
 from six import string_types
 
-from arango.api import api_method
 from arango.collections.base import BaseCollection
 from arango.exceptions import *
 from arango.request import Request
@@ -33,7 +32,6 @@ class Collection(BaseCollection):
     def __repr__(self):
         return '<ArangoDB collection "{}">'.format(self._name)
 
-    @api_method
     def get(self, key, rev=None, match_rev=True):
         """Retrieve a document by its key.
 
@@ -71,9 +69,8 @@ class Collection(BaseCollection):
                 return res.body
             raise DocumentGetError(res)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def insert(self, document, return_new=False, sync=None):
         """Insert a new document into the collection.
 
@@ -127,9 +124,8 @@ class Collection(BaseCollection):
                 res.body['sync'] = True
             return res.body
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def insert_many(self, documents, return_new=False, sync=None):
         """Insert multiple documents into the collection.
 
@@ -191,9 +187,8 @@ class Collection(BaseCollection):
                 results.append(result)
             return results
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def update(self,
                document,
                merge=True,
@@ -283,9 +278,8 @@ class Collection(BaseCollection):
             res.body['_old_rev'] = res.body.pop('_oldRev')
             return res.body
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def update_many(self,
                     documents,
                     merge=True,
@@ -388,9 +382,8 @@ class Collection(BaseCollection):
 
             return results
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def update_match(self,
                      filters,
                      body,
@@ -449,9 +442,8 @@ class Collection(BaseCollection):
                 raise DocumentUpdateError(res)
             return res.body['updated']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def replace(self,
                 document,
                 return_new=False,
@@ -536,9 +528,8 @@ class Collection(BaseCollection):
             res.body['_old_rev'] = res.body.pop('_oldRev')
             return res.body
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def replace_many(self,
                      documents,
                      return_new=False,
@@ -631,9 +622,8 @@ class Collection(BaseCollection):
 
             return results
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def replace_match(self, filters, body, limit=None, sync=None):
         """Replace matching documents in the collection.
 
@@ -682,9 +672,8 @@ class Collection(BaseCollection):
                 raise DocumentReplaceError(res)
             return res.body['replaced']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete(self,
                document,
                ignore_missing=False,
@@ -769,9 +758,8 @@ class Collection(BaseCollection):
                 res.body['sync'] = True
             return res.body
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete_many(self,
                     documents,
                     return_old=False,
@@ -846,9 +834,8 @@ class Collection(BaseCollection):
 
             return results
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete_match(self, filters, limit=None, sync=None):
         """Delete matching documents from the collection.
 
@@ -885,9 +872,8 @@ class Collection(BaseCollection):
                 raise DocumentDeleteError(res)
             return res.body['deleted']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def import_bulk(self,
                     documents,
                     halt_on_error=None,
@@ -995,4 +981,4 @@ class Collection(BaseCollection):
                 raise DocumentInsertError(res)
             return res.body
 
-        return request, handler
+        return self.handle_request(request, handler)

--- a/arango/collections/vertex.py
+++ b/arango/collections/vertex.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-from arango.api import api_method
 from arango.collections.base import BaseCollection
 from arango.exceptions import *
 from arango.request import Request
@@ -47,7 +46,6 @@ class VertexCollection(BaseCollection):
         """
         return self._graph_name
 
-    @api_method
     def get(self, key, rev=None):
         """Fetch a document by key from the vertex collection.
 
@@ -80,9 +78,8 @@ class VertexCollection(BaseCollection):
                 raise DocumentGetError(res)
             return res.body['vertex']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def insert(self, document, sync=None):
         """Insert a new document into the vertex collection.
 
@@ -116,9 +113,8 @@ class VertexCollection(BaseCollection):
                 raise DocumentInsertError(res)
             return res.body['vertex']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def update(self, document, keep_none=True, sync=None):
         """Update a document by its key in the vertex collection.
 
@@ -169,9 +165,8 @@ class VertexCollection(BaseCollection):
             vertex['_old_rev'] = vertex.pop('_oldRev')
             return vertex
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def replace(self, document, sync=None):
         """Replace a document by its key in the vertex collection.
 
@@ -218,9 +213,8 @@ class VertexCollection(BaseCollection):
             vertex['_old_rev'] = vertex.pop('_oldRev')
             return vertex
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete(self, document, ignore_missing=False, sync=None):
         """Delete a document by its key from the vertex collection.
 
@@ -270,4 +264,4 @@ class VertexCollection(BaseCollection):
                 raise DocumentDeleteError(res)
             return res.body['removed']
 
-        return request, handler
+        return self.handle_request(request, handler)

--- a/arango/database.py
+++ b/arango/database.py
@@ -368,7 +368,7 @@ class Database(object):
         res = self._conn.post('/_admin/routing/reload')
         if res.status_code not in HTTP_OK:
             raise ServerReloadRoutingError(res)
-        return not res.body['error']
+        return 'error' not in res.body
 
     def async(self, return_result=True):
         """Return the asynchronous request object.

--- a/arango/graph.py
+++ b/arango/graph.py
@@ -7,7 +7,7 @@ from arango.collections import (
 from arango.utils import HTTP_OK
 from arango.exceptions import *
 from arango.request import Request
-from arango.api import APIWrapper, api_method
+from arango.api import APIWrapper
 
 
 class Graph(APIWrapper):
@@ -22,7 +22,7 @@ class Graph(APIWrapper):
     """
 
     def __init__(self, connection, name):
-        self._conn = connection
+        super(Graph, self).__init__(connection)
         self._name = name
 
     def __repr__(self):
@@ -57,7 +57,6 @@ class Graph(APIWrapper):
         """
         return EdgeCollection(self._conn, self._name, name)
 
-    @api_method
     def properties(self):
         """Return the graph properties.
 
@@ -92,13 +91,12 @@ class Graph(APIWrapper):
                 'smart_field': record.get('smartGraphAttribute'),
                 'shard_count': record.get('numberOfShards')
             }
-        return request, handler
+        return self.handle_request(request, handler)
 
     ################################
     # Vertex Collection Management #
     ################################
 
-    @api_method
     def orphan_collections(self):
         """Return the orphan vertex collections of the graph.
 
@@ -117,9 +115,8 @@ class Graph(APIWrapper):
                 raise OrphanCollectionListError(res)
             return res.body['graph']['orphanCollections']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def vertex_collections(self):
         """Return the vertex collections of the graph.
 
@@ -138,9 +135,8 @@ class Graph(APIWrapper):
                 raise VertexCollectionListError(res)
             return res.body['collections']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def create_vertex_collection(self, name):
         """Create a vertex collection for the graph.
 
@@ -162,9 +158,8 @@ class Graph(APIWrapper):
                 raise VertexCollectionCreateError(res)
             return VertexCollection(self._conn, self._name, name)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete_vertex_collection(self, name, purge=False):
         """Remove the vertex collection from the graph.
 
@@ -188,13 +183,12 @@ class Graph(APIWrapper):
                 raise VertexCollectionDeleteError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
     ##############################
     # Edge Definition Management #
     ##############################
 
-    @api_method
     def edge_definitions(self):
         """Return the edge definitions of the graph.
 
@@ -221,9 +215,8 @@ class Graph(APIWrapper):
                 res.body['graph']['edgeDefinitions']
             ]
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def create_edge_definition(self, name, from_collections, to_collections):
         """Create a new edge definition for the graph.
 
@@ -256,9 +249,8 @@ class Graph(APIWrapper):
                 raise EdgeDefinitionCreateError(res)
             return EdgeCollection(self._conn, self._name, name)
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def replace_edge_definition(self, name, from_collections, to_collections):
         """Replace an edge definition in the graph.
 
@@ -290,9 +282,8 @@ class Graph(APIWrapper):
                 raise EdgeDefinitionReplaceError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
-    @api_method
     def delete_edge_definition(self, name, purge=False):
         """Remove an edge definition from the graph.
 
@@ -316,13 +307,12 @@ class Graph(APIWrapper):
                 raise EdgeDefinitionDeleteError(res)
             return not res.body['error']
 
-        return request, handler
+        return self.handle_request(request, handler)
 
     ####################
     # Graph Traversals #
     ####################
 
-    @api_method
     def traverse(self,
                  start_vertex,
                  direction='outbound',
@@ -435,4 +425,4 @@ class Graph(APIWrapper):
                 raise GraphTraverseError(res)
             return res.body['result']['visited']
 
-        return request, handler
+        return self.handle_request(request, handler)

--- a/scripts/setup_arangodb_mac.sh
+++ b/scripts/setup_arangodb_mac.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+which -s brew
+if [[ $? != 0 ]] ; then
+    # Install Homebrew
+    # https://github.com/mxcl/homebrew/wiki/installation
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.github.com/gist/323731)"
+else
+    brew update
+fi
+
+if brew ls --versions arangodb > /dev/null; then
+  echo "arangod already installed"
+else
+  brew install arangodb
+fi
+
+ARCH=$(arch)
+PID=$(echo $PPID)
+TMP_DIR="/tmp/arangodb.$PID"
+PID_FILE="/tmp/arangodb.$PID.pid"
+
+ARANGODB_DIR="/usr/local/opt/arangodb"
+
+ARANGOD="${ARANGODB_DIR}/sbin/arangod"
+
+# create database directory
+mkdir ${TMP_DIR}
+
+echo "Starting ArangoDB '${ARANGOD}'"
+
+${ARANGOD} \
+    --database.directory ${TMP_DIR} \
+    --configuration none \
+    --server.endpoint tcp://127.0.0.1:8529 \
+    --javascript.app-path ${ARANGODB_DIR}/share/arangodb3/js/apps \
+    --javascript.startup-directory ${ARANGODB_DIR}/share/arangodb3/js \
+    --database.maximal-journal-size 1048576 &
+
+sleep 2
+
+echo "Check for arangod process"
+process=$(ps auxww | grep "bin/arangod" | grep -v grep)
+
+if [ "x$process" == "x" ]; then
+  echo "no 'arangod' process found"
+  echo "ARCH = $ARCH"
+  exit 1
+fi
+
+echo "Waiting until ArangoDB is ready on port 8529"
+sleep 10
+
+echo "ArangoDB is up"


### PR DESCRIPTION
Hello,

I was working with your library and noticed that you were implementing the connection passthrough using a monkey patch to __getattribute__.  This makes it quite difficult to determine where in the code the function calls to connection.handle_request were occuring.  I have refactored it to deal with this in a better manner, using a base class with a handle_request method.

Secondly, I made two changes, one in client and one in database, where they were failing on a key error in python 3.  I have replaced these to use what I believe to be an equivalent syntax.

Third, I have added a setup_arango_mac.sh script.

Lastly, this appears to fail 3 tests for permissions management reasons.

In test_user line 228, it appears nonexistent users access checking now throws arango.exceptions.UserAccessError: [HTTP 404][ERR 1703] user not found in the most recent arangodb, instead of returning []

In the test_grant_user_access_collection_level and test_revoke_user_access_collection_level functions, it appears to fail because it attempts to call the _db/{DBNAME}/_api/user/{user}/database/{dbname}/{collection} endpoint for col.grant_user_access, which doesnt exist, when it should be calling the /_api/user/{user}/database/{dbname}/{collection} endpoint.  I don't know what your preferred solution to this would be.

-Daniel Collins