### PR TITLE
Add changes to make BatchExecution thread safe

### DIFF
--- a/arango/database.py
+++ b/arango/database.py
@@ -422,11 +422,12 @@ class Database(object):
         :param return_result: store and return the result
         :type return_result: bool
         :returns: the async request object
-        :rtype: arango.async.AsyncExecution
+        :rtype: :class:`arango.async.AsyncExecution`
         """
         return AsyncExecution(self._conn, return_result)
 
-    def batch(self, return_result=True, commit_on_error=True):
+    def batch(self, return_result=True, commit_on_error=True,
+              submit_timeout=-1):
         """Return the batch request object.
 
         Refer to :class:`arango.batch.BatchExecution` for more information.
@@ -435,10 +436,18 @@ class Database(object):
         :type return_result: bool
         :param commit_on_error: commit when an exception is raised
             (this is only applicable when context managers are used)
+        :type commit_on_error: bool
+        :param submit_timeout: the timeout to use for acquiring the lock
+        necessary to submit a batch.  Only relevant in multi-threaded contexts.
+        In single threaded contexts, acquiring this lock will never fail.
+        A value of <= 0 means wait forever, a positive value indicates the
+        number of seconds to wait.
+        :type submit_timeout: int
         :returns: the batch request object
-        :rtype: arango.batch.BatchExecution
+        :rtype: :class:`arango.batch.BatchExecution`
         """
-        return BatchExecution(self._conn, return_result, commit_on_error)
+        return BatchExecution(self._conn, return_result, commit_on_error,
+                              submit_timeout)
 
     def transaction(self,
                     read=None,

--- a/arango/lock.py
+++ b/arango/lock.py
@@ -1,0 +1,36 @@
+import six
+
+
+if six.PY2:
+    import Queue
+
+
+    class Lock(object):
+        """Implementation of a lock with a timeout for python 2.
+
+        https://stackoverflow.com/questions/35149889/lock-with-timeout-in-python2-7
+        """
+
+        def __init__(self):
+            self._queue = Queue.Queue(maxsize=1)
+            self._queue.put(True, block=False)
+
+        def acquire(self, timeout=-1):
+            if timeout <= 0:
+                timeout = None
+
+            try:
+                return self._queue.get(block=True, timeout=timeout)
+            except Queue.Empty:
+                return False
+
+        def release(self):
+            self._queue.put(True, block=False)
+
+        def __enter__(self):
+            self.acquire()
+
+        def __exit__(self, exc_type, exc_val, exc_tb):
+            self.release()
+else:
+    from threading import Lock


### PR DESCRIPTION
Simple, blocking implementation of BatchExecution.  This implementation uses locks to manage write control over the object.  However, the lock implementation in python 2 does not have a timeout option.  Therefore, one had to be created for python 2 based on Queue.Queue.  In python 3, threading.Lock is used.