### PR TITLE
Submission that removes kwargs structure

### DIFF
--- a/arango/api.py
+++ b/arango/api.py
@@ -8,11 +8,10 @@ class APIWrapper:
         self._conn = connection
 
     def handle_request(self, request, handler, job_class=None,
-                       use_underlying=False, **kwargs):
+                       use_underlying=False):
         if use_underlying:
             connection = self._conn.underlying
         else:
             connection = self._conn
 
-        return connection.handle_request(request, handler, job_class=job_class,
-                                         **kwargs)
+        return connection.handle_request(request, handler, job_class=job_class)

--- a/arango/connections/base.py
+++ b/arango/connections/base.py
@@ -79,6 +79,10 @@ class BaseConnection(object):
 
     @property
     def underlying(self):
+        """
+        :return: the root connection this is based upon
+        :rtype: arango.connections.BaseConnection
+        """
         if self._parent is None:
             return self
         else:
@@ -173,8 +177,7 @@ class BaseConnection(object):
     def async_ready(self):
         return self._async_ready
 
-    def handle_request(self, request, handler, job_class=None,
-                       **kwargs):
+    def handle_request(self, request, handler, job_class=None):
         """Handle a given request
 
         :param request: The request to make
@@ -184,8 +187,6 @@ class BaseConnection(object):
         :param job_class: the class of the :class:arango.jobs.BaseJob to
         output or None to use the default job for this connection
         :type job_class: class | None
-        :param kwargs: keyword arguments to be passed to the
-        :class:arango.jobs.BaseJob constructor
         :return: the job output
         :rtype: arango.jobs.BaseJob
         """
@@ -215,7 +216,7 @@ class BaseConnection(object):
             request.auth = (self._username, self._password)
 
         response = self._http.make_request(request)
-        return job_class(used_handler, response, **kwargs)
+        return job_class(used_handler, response=response)
 
     @property
     def aql(self):

--- a/arango/connections/cluster.py
+++ b/arango/connections/cluster.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 from arango.connections.base import BaseConnection
+from arango.exceptions import ArangoError
 
 
 class ClusterTest(BaseConnection):
@@ -56,18 +57,24 @@ class ClusterTest(BaseConnection):
     def __repr__(self):
         return '<ArangoDB cluster round-trip test>'
 
-    def handle_request(self, request, handler, **kwargs):
+    def handle_request(self, request, handler, job_class=None):
         """Handle the incoming request and response handler.
 
         :param request: the API request to be placed in the server-side queue
         :type request: arango.request.Request
         :param handler: the response handler
         :type handler: callable
+        :param job_class: the class of the :class:arango.jobs.BaseJob to
+        output or None to use the default job for this connection
+        :type job_class: class | None
         :returns: the test results
         :rtype: dict
         :raises arango.exceptions.ClusterTestError: if the cluster round-trip
             test cannot be executed
         """
+        if job_class is not None:
+            raise ArangoError('')
+
         request.headers['X-Shard-ID'] = str(self._shard_id)
         if self._trans_id is not None:
             request.headers['X-Client-Transaction-ID'] = str(self._trans_id)
@@ -76,4 +83,4 @@ class ClusterTest(BaseConnection):
         if self._sync is True:
             request.headers['X-Synchronous-Mode'] = 'true'
 
-        return BaseConnection.handle_request(self, request, handler)
+        return BaseConnection.handle_request(self, request, handler, job_class)

--- a/arango/connections/transaction.py
+++ b/arango/connections/transaction.py
@@ -85,7 +85,7 @@ class Transaction(BaseConnection):
         """
         return self._id
 
-    def handle_request(self, request, handler, **kwargs):
+    def handle_request(self, request, handler, job_class=None):
         """Handle the incoming request and response handler.
 
         :param request: the API request queued as part of the transaction, and
@@ -94,7 +94,14 @@ class Transaction(BaseConnection):
         :type request: arango.request.Request
         :param handler: the response handler
         :type handler: callable
+        :param job_class: required to maintain compatibility with the
+        BaseConnection interface, but should be None for a transaction
         """
+
+        if job_class is not None:
+            raise TransactionError('transaction cannot called with a '
+                                   'job_class other than none')
+
         if request.command is None:
             raise TransactionError('unsupported method')
         self._actions.append(request.command)

--- a/arango/exceptions/base.py
+++ b/arango/exceptions/base.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 from six import string_types as string
 
-from arango.responses import BaseResponse
+from arango.responses import Response
 
 
 class ArangoError(Exception):
@@ -13,7 +13,7 @@ class ArangoError(Exception):
     """
 
     def __init__(self, data, message=None):
-        if isinstance(data, BaseResponse):
+        if isinstance(data, Response):
             # Get the ArangoDB error message if provided
             if message is not None:
                 error_message = message

--- a/arango/http_clients/base.py
+++ b/arango/http_clients/base.py
@@ -20,7 +20,7 @@ class BaseHTTPClient(object):  # pragma: no cover
          none, uses self.response_mapper.
         :type response_mapper: callable
         :return: The response to this request
-        :rtype: arango.responses.BaseResponse
+        :rtype: arango.responses.Response
         """
 
         raise NotImplementedError

--- a/arango/http_clients/default.py
+++ b/arango/http_clients/default.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import requests
 
-from arango.responses import BaseResponse
+from arango.responses import Response
 from arango.http_clients import BaseHTTPClient
 
 
@@ -30,7 +30,7 @@ class DefaultHTTPClient(BaseHTTPClient):
          none, uses self.response_mapper.
         :type response_mapper: callable
         :return: The response to this request
-        :rtype: arango.responses.BaseResponse
+        :rtype: arango.responses.Response
         """
 
         if response_mapper is None:
@@ -39,7 +39,7 @@ class DefaultHTTPClient(BaseHTTPClient):
         method = request.method
 
         res = self._session.request(method, **request.kwargs)
-        return BaseResponse(res, response_mapper)
+        return Response(res, response_mapper)
 
     @staticmethod
     def response_mapper(response):

--- a/arango/jobs/base.py
+++ b/arango/jobs/base.py
@@ -9,7 +9,8 @@ class BaseJob(object):
     A job tracks the status of an API request and its result.
     """
 
-    def __init__(self, handler, response=None, job_id=None, assign_id=False, job_type='base'):
+    def __init__(self, handler, response=None, job_id=None, assign_id=True,
+                 job_type='base'):
         if job_id is None and assign_id:
             job_id = uuid4().hex
 
@@ -40,7 +41,7 @@ class BaseJob(object):
         :param status: the status of the job
         :type status: str
         :param response: the response to the job
-        :type response: arango.responses.base.BaseResponse
+        :type response: arango.responses.base.Response
         """
 
         self._status = status

--- a/arango/jobs/batch.py
+++ b/arango/jobs/batch.py
@@ -8,9 +8,8 @@ class BatchJob(BaseJob):
     A batch job tracks the status of a queued API request and its result.
     """
 
-    def __init__(self, handler, job_id=None, response=None):
-        BaseJob.__init__(self, handler, job_id=job_id, response=response,
-                         job_type='batch')
+    def __init__(self, handler, response=None):
+        BaseJob.__init__(self, handler, response=response, job_type='batch')
         self._lock = RLock()
 
     def update(self, status, response=None):
@@ -21,7 +20,7 @@ class BatchJob(BaseJob):
         :param status: the status of the job
         :type status: str
         :param response: the response to the job
-        :type response: arango.responses.base.BaseResponse
+        :type response: arango.responses.base.Response
         """
 
         with self._lock:

--- a/arango/jobs/sync.py
+++ b/arango/jobs/sync.py
@@ -2,8 +2,8 @@ from arango.jobs import BaseJob
 
 
 class SynchronousResultJob(BaseJob):
-    def __new__(cls, handler, response=None, job_id=None):
-        job = BaseJob(handler, response=response, job_id=job_id)
+    def __new__(cls, handler, response=None):
+        job = BaseJob(handler, response=response)
 
         res = job.result(raise_errors=True)
 

--- a/arango/responses/__init__.py
+++ b/arango/responses/__init__.py
@@ -1,2 +1,2 @@
-from arango.responses.base import BaseResponse
+from arango.responses.base import Response
 from arango.responses.lazy import LazyResponse

--- a/arango/responses/base.py
+++ b/arango/responses/base.py
@@ -1,7 +1,7 @@
 import json
 
 
-class BaseResponse(object):
+class Response(object):
     """ArangoDB HTTP response.
 
     Overridden methods of :class:`arango.http_clients.base.BaseHTTPClient` must

--- a/arango/responses/lazy.py
+++ b/arango/responses/lazy.py
@@ -1,7 +1,7 @@
-from arango.responses import BaseResponse
+from arango.responses import Response
 
 
-class LazyResponse(BaseResponse):  # pragma: no cover
+class LazyResponse(Response):  # pragma: no cover
     """Response which lazily loads all values from some future.
 
     :param future: The future instance which has the function result()"
@@ -19,7 +19,7 @@ class LazyResponse(BaseResponse):  # pragma: no cover
     def __getattr__(self, item):
         if item in self.__slots__:
             future_result = self._future.result()
-            BaseResponse.__init__(
+            Response.__init__(
                 self,
                 future_result,
                 self._response_mapper

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ else:
 setup(
     name='python-arango',
     description='Python Driver for ArangoDB',
-    version=version['__VERSION__'],
+    version=version['__version__'],
     author='Joohwan Oh',
     author_email='joohwan.oh@outlook.com',
     url='https://github.com/joowani/python-arango',


### PR DESCRIPTION
This submission cleans up the job kwargs concept by removing it entirely.  Scanning the entire codebase again, I was able to replace most of it with a single call to functools.partial