### PR TITLE
Honor read and write params to begin_transaction

### DIFF
--- a/arango/executor.py
+++ b/arango/executor.py
@@ -347,7 +347,16 @@ class TransactionExecutor(Executor):
             return self.jobs
 
         write_collections = set()
+        if isinstance(self._write, string_types):
+            write_collections.add(self._write)
+        elif self._write is not None:
+            write_collections |= set(self._write)
+
         read_collections = set()
+        if isinstance(self._read, string_types):
+            read_collections.add(self._read)
+        elif self._read is not None:
+            read_collections |= set(self._read)
 
         # Buffer for building the transaction javascript command
         cmd_buffer = [


### PR DESCRIPTION
In my application, I saw an error where a transaction containing only AQL would fail because the write collections were not declared. I traced this to the `read` and `write` parameters to `begin_transaction` not being passed all the way through to the database in `commit`.