### PR TITLE
Remove duplicate '_count' slot from Cursor

### DIFF
--- a/arango/cursor.py
+++ b/arango/cursor.py
@@ -38,8 +38,7 @@ class Cursor(object):
         '_profile',
         '_warnings',
         '_has_more',
-        '_batch',
-        '_count'
+        '_batch'
     ]
 
     def __init__(self, connection, init_data, cursor_type='cursor'):


### PR DESCRIPTION
The `'_count'` slot was already defined on line 35.