### PR TITLE
Allow configuring schema property for existing collections

### DIFF
--- a/arango/collection.py
+++ b/arango/collection.py
@@ -306,11 +306,13 @@ class Collection(APIWrapper):
 
         return self._execute(request, response_handler)
 
-    def configure(self, sync=None):
+    def configure(self, sync=None, schema=None):
         """Configure collection properties.
 
         :param sync: Block until operations are synchronized to disk.
         :type sync: bool
+        :param schema: document schema for validation of objects.
+        :type schema: dict
         :return: New collection properties.
         :rtype: dict
         :raise arango.exceptions.CollectionConfigureError: If operation fails.
@@ -318,6 +320,8 @@ class Collection(APIWrapper):
         data = {}
         if sync is not None:
             data['waitForSync'] = sync
+        if schema is not None:
+            data['schema'] = schema
 
         request = Request(
             method='put',


### PR DESCRIPTION
Although not entirely clear from this documentation: https://www.arangodb.com/docs/3.7/data-modeling-collections-collection-methods.html#properties

This page indicates it should be possible to set the schema property for existing collections: https://www.arangodb.com/docs/3.7/data-modeling-documents-schema-validation.html